### PR TITLE
404 not found/simple_get

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+os: osx
+
+language: java
+jdk: openjdk11
+
+before_cache:
+  - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock
+  - rm -fr $HOME/.gradle/caches/*/plugin-resolution/
+cache:
+  directories:
+    - $HOME/.gradle/caches/
+    - $HOME/.gradle/wrapper/
+
+script:
+  - ./gradlew test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-An HTTP web server built in Java.
+
+
+### Hyperion HTTP Server
+A web server that implements HTTP written in Java. 
+
+### Requirements
+- Software: [Java 11](https://adoptopenjdk.net/)
+- Build tool: [Gradle 5.4.1](https://gradle.org/install/)
+
+
+### Getting Started
+Clone this repo to your local machine: https://github.com/lpenzey/hyperion.git
+
+### Usage
+1. Start the server: In a terminal window, cd into the project directory's src folder:
+```
+$ cd hyperion/src
+```
+Then run the following command to compile and run the server, making sure to pass in a port number 
+(running the below command will start the server on port 5000)
+```
+$ javac main/java/server/Server.java && java main/java/server/Server 5000
+```
+2. Once running on the specified port, enter the following in a web browser 
+```
+127.0.0.1:5000
+```
+This will return a 404 Not Found code. To receive a 200 OK response, enter the following:
+```
+127.0.0.1:5000/simple_get
+```
+
+### Running the tests
+In the terminal window, navigate to the project's root folder and run the following command:
+```
+$ gradle test
+```
+

--- a/README.md
+++ b/README.md
@@ -12,23 +12,25 @@ A web server that implements HTTP written in Java.
 Clone this repo to your local machine: https://github.com/lpenzey/hyperion.git
 
 ### Usage
-1. Start the server: In a terminal window, cd into the project directory's src folder:
+1 - In the terminal, navigate to the cloned project's root folder and run the following command to create a package:
 ```
-$ cd hyperion/src
+$ ./gradlew jar
 ```
-Then run the following command to compile and run the server, making sure to pass in a port number 
-(running the below command will start the server on port 5000)
+2 - Then run the following to build the project:
 ```
-$ javac main/java/server/Server.java && java main/java/server/Server 5000
+$ ./gradlew build
 ```
-2. Once running on the specified port, enter the following in a web browser 
+3 - Once built run the following to start the server on a given port (port 5000 in the example below):
 ```
-127.0.0.1:5000
+$ java -jar build/libs/hyperion.jar 5000
 ```
-This will return a 404 Not Found code. To receive a 200 OK response, enter the following:
+4 - Send a request to the server on the same port:
 ```
-127.0.0.1:5000/simple_get
+localhost:5000/simple_get
 ```
+
+***Note that in the server's current phase it only returns a 200 OK status and no body when given "/simple_get" as the path. 
+All other requests will return 404 Not Found.***
 
 ### Running the tests
 In the terminal window, navigate to the project's root folder and run the following command:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/lpenzey/hyperion.svg?branch=master)](https://travis-ci.org/lpenzey/hyperion) [![Maintainability](https://api.codeclimate.com/v1/badges/60d82bfebc6fec4f85d7/maintainability)](https://codeclimate.com/github/lpenzey/hyperion/maintainability) [![Test Coverage](https://api.codeclimate.com/v1/badges/60d82bfebc6fec4f85d7/test_coverage)](https://codeclimate.com/github/lpenzey/hyperion/test_coverage)
+
 
 
 ### Hyperion HTTP Server

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,22 @@
-apply plugin: 'java'
-
+plugins {
+    id 'application'
+    id 'java'
+}
 repositories {
     mavenCentral()
+}
+
+application {
+    mainClassName = '.Server'
+}
+
+jar {
+    manifest {
+        attributes(
+                'Main-Class': 'main/java/server/Server'
+        )
+    }
+
 }
 
 dependencies {

--- a/src/main/java/server/Client.java
+++ b/src/main/java/server/Client.java
@@ -2,6 +2,7 @@ package main.java.server;
 
 import java.io.*;
 import java.net.Socket;
+import java.util.logging.Level;
 
 public class Client {
 
@@ -25,7 +26,7 @@ public class Client {
         try {
             clientSocket.close();
         } catch(IOException error) {
-            System.err.println(error);
+            ServerLogger.serverLogger.log(Level.INFO, "Error: " + error);
         }
     }
 }

--- a/src/main/java/server/Client.java
+++ b/src/main/java/server/Client.java
@@ -5,7 +5,7 @@ import java.net.Socket;
 
 public class Client {
 
-    Socket clientSocket;
+    private final Socket clientSocket;
     private BufferedReader reader;
     private PrintWriter writer;
 

--- a/src/main/java/server/Client.java
+++ b/src/main/java/server/Client.java
@@ -16,9 +16,7 @@ public class Client {
         this.writer = new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream()), true);
     }
 
-    public BufferedReader getReader() {
-        return reader;
-    }
+    public BufferedReader getReader() { return reader; }
 
     public PrintWriter getWriter() { return writer; }
 
@@ -26,7 +24,7 @@ public class Client {
         try {
             clientSocket.close();
         } catch(IOException error) {
-            ServerLogger.serverLogger.log(Level.INFO, "Error: " + error);
+            ServerLogger.serverLogger.log(Level.WARNING, "Error: " + error);
         }
     }
 }

--- a/src/main/java/server/Client.java
+++ b/src/main/java/server/Client.java
@@ -1,0 +1,31 @@
+package main.java.server;
+
+import java.io.*;
+import java.net.Socket;
+
+public class Client {
+
+    Socket clientSocket;
+    private BufferedReader reader;
+    private PrintWriter writer;
+
+    public Client(Socket clientSocket) throws IOException {
+        this.clientSocket = clientSocket;
+        this.reader = new BufferedReader(new InputStreamReader(clientSocket.getInputStream()));
+        this.writer = new PrintWriter(new OutputStreamWriter(clientSocket.getOutputStream()), true);
+    }
+
+    public BufferedReader getReader() {
+        return reader;
+    }
+
+    public PrintWriter getWriter() { return writer; }
+
+    public void close() {
+        try {
+            clientSocket.close();
+        } catch(IOException error) {
+            System.err.println(error);
+        }
+    }
+}

--- a/src/main/java/server/ProtocolRunner.java
+++ b/src/main/java/server/ProtocolRunner.java
@@ -1,12 +1,12 @@
 package main.java.server;
 
-import main.java.server.request.Request;
-import main.java.server.request.RequestParser;
-
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.logging.Level;
+
+import main.java.server.request.Request;
+import main.java.server.request.RequestParser;
 
 
 class ProtocolRunner implements Runnable {

--- a/src/main/java/server/ProtocolRunner.java
+++ b/src/main/java/server/ProtocolRunner.java
@@ -1,0 +1,38 @@
+package main.java.server;
+
+import main.java.server.request.Request;
+import main.java.server.request.RequestParser;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.logging.Level;
+
+
+class ProtocolRunner implements Runnable {
+    private final RequestParser requestParser = new RequestParser();
+    private final Router router = new Router();
+    private final Client client;
+    private final BufferedReader in;
+    private final PrintWriter out;
+
+    public ProtocolRunner(Client client) {
+        this.client = client;
+        this.in = client.getReader();
+        this.out = client.getWriter();
+    }
+
+    public void run() {
+        try {
+            String input = in.readLine();
+            while(input != null) {
+                Request request = requestParser.create(input);
+                String response = router.route(request);
+                out.print(response);
+                out.flush();
+                client.close();
+            }
+        } catch(IOException error) {
+            ServerLogger.serverLogger.log(Level.WARNING, "Error: " + error);        }
+    }
+}

--- a/src/main/java/server/Router.java
+++ b/src/main/java/server/Router.java
@@ -4,15 +4,17 @@ import main.java.server.request.Request;
 
 import java.util.HashMap;
 
+import static main.java.server.StatusCodes.*;
+
 public class Router {
 
     public String route(Request request) {
         HashMap<String, String> requestHeaders = request.getHeaders();
         String path = requestHeaders.get("path");
         if (path.equals("/simple_get")) {
-            return "HTTP/1.1 200 OK\r\n";
+            return OK;
         } else {
-            return "HTTP/1.1 404 Not Found\r\n";
+            return NOT_FOUND;
         }
     }
 

--- a/src/main/java/server/Router.java
+++ b/src/main/java/server/Router.java
@@ -1,10 +1,10 @@
 package main.java.server;
 
+import java.util.HashMap;
 import main.java.server.request.Request;
 
-import java.util.HashMap;
-
-import static main.java.server.StatusCodes.*;
+import static main.java.server.StatusCodes.NOT_FOUND;
+import static main.java.server.StatusCodes.OK;
 
 public class Router {
 

--- a/src/main/java/server/Router.java
+++ b/src/main/java/server/Router.java
@@ -1,0 +1,19 @@
+package main.java.server;
+
+import main.java.server.request.Request;
+
+import java.util.HashMap;
+
+public class Router {
+
+    public String route(Request request) {
+        HashMap<String, String> requestHeaders = request.getHeaders();
+        String path = requestHeaders.get("path");
+        if (path.equals("/simple_get")) {
+            return "HTTP/1.1 200 OK\r\n";
+        } else {
+            return "HTTP/1.1 404 Not Found\r\n";
+        }
+    }
+
+}

--- a/src/main/java/server/Server.java
+++ b/src/main/java/server/Server.java
@@ -1,0 +1,40 @@
+package main.java.server;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.logging.Level;
+
+class Server {
+    private final Integer port;
+    private boolean serverIsRunning = true;
+
+    private Server(Integer port) {
+        this.port = port;
+    }
+
+    public static void main(String[] args) throws IOException {
+            int port = Integer.parseInt(args[0]);
+            try {Server server = new Server(port);
+                server.start();
+            } catch (IOException error) {
+                ServerLogger.serverLogger.log(Level.INFO, "Error: " + error);
+        }
+
+    }
+
+    private void start() throws IOException {
+        ServerSocket serverSocket = new ServerSocket(port);
+        while(serverIsRunning) {
+            Socket clientSocket = serverSocket.accept();
+            Client client = new Client(clientSocket);
+            ProtocolRunner protocol = new ProtocolRunner(client);
+            (new Thread(protocol)).start();
+        }
+        serverSocket.close();
+    }
+
+    private void stop() throws IOException {
+        serverIsRunning = false;
+    }
+}

--- a/src/main/java/server/Server.java
+++ b/src/main/java/server/Server.java
@@ -18,7 +18,7 @@ class Server {
             try {Server server = new Server(port);
                 server.start();
             } catch (IOException error) {
-                ServerLogger.serverLogger.log(Level.INFO, "Error: " + error);
+                ServerLogger.serverLogger.log(Level.SEVERE, "Error: " + error);
         }
 
     }
@@ -34,7 +34,7 @@ class Server {
         serverSocket.close();
     }
 
-    private void stop() throws IOException {
+    private void stop() {
         serverIsRunning = false;
     }
 }

--- a/src/main/java/server/ServerLogger.java
+++ b/src/main/java/server/ServerLogger.java
@@ -1,0 +1,7 @@
+package main.java.server;
+
+import java.util.logging.Logger;
+
+class ServerLogger {
+    final static Logger serverLogger = Logger.getLogger(ServerLogger.class.getName());
+}

--- a/src/main/java/server/StatusCodes.java
+++ b/src/main/java/server/StatusCodes.java
@@ -1,0 +1,11 @@
+package main.java.server;
+
+class StatusCodes {
+    private StatusCodes() {}
+
+    public static final String VERSION = "HTTP/1.1";
+    public static final String SP = " ";
+    public static final String CRLF = "\r\n";
+    public static final String NOT_FOUND = "HTTP/1.1 404 Not Found\r\n";
+    public static final String OK = "HTTP/1.1 200 OK\r\n";
+}

--- a/src/main/java/server/request/Request.java
+++ b/src/main/java/server/request/Request.java
@@ -1,0 +1,25 @@
+package main.java.server.request;
+
+import java.util.HashMap;
+
+public class Request {
+
+    private HashMap<String, String> headers;
+    private String body;
+
+    public void setHeaders(HashMap<String, String> headers) {
+        this.headers = headers;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+
+    public HashMap<String, String> getHeaders() {
+        return headers;
+    }
+
+    public String getBody() {
+        return body;
+    }
+}

--- a/src/main/java/server/request/RequestParser.java
+++ b/src/main/java/server/request/RequestParser.java
@@ -1,0 +1,38 @@
+package main.java.server.request;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+public class RequestParser {
+
+    private String[] segmentedRequest;
+    private final HashMap<String, String> headers = new HashMap<>();
+
+    public Request create(String incomingRequest) {
+        this.segmentedRequest  = incomingRequest.split("\r\n")[0].split(" ");
+        Request request = new Request();
+        HashMap<String, String> headers = buildHeaders();
+        request.setHeaders(headers);
+        return request;
+    }
+
+    private HashMap<String, String> buildHeaders() {
+        String method = getMethod();
+        String path = getPath();
+        String version = getVersion();
+        headers.put("method", method);
+        headers.put("path", path);
+        headers.put("version", version);
+        return headers;
+    }
+
+    private String getMethod() { return segmentedRequest[0]; }
+
+    private String getPath() {
+        return segmentedRequest[1];
+    }
+
+    private String getVersion() {
+        return segmentedRequest[2];
+    }
+}

--- a/src/main/java/server/request/RequestParser.java
+++ b/src/main/java/server/request/RequestParser.java
@@ -3,35 +3,34 @@ package main.java.server.request;
 import java.util.HashMap;
 
 public class RequestParser {
-
-    private String[] segmentedRequest;
-    private final HashMap<String, String> headers = new HashMap<>();
+    private static final int REQUEST_METHOD_INDEX = 0;
+    private static final int REQUEST_PATH_INDEX = 1;
+    private static final int REQUEST_VERSION_INDEX = 2;
 
     public Request create(String incomingRequest) {
-        this.segmentedRequest  = incomingRequest.split("\r\n")[0].split(" ");
+        String[] segmentedRequest = incomingRequest.split("\r\n")[0].split(" ");
         Request request = new Request();
-        HashMap<String, String> headers = buildHeaders();
-        request.setHeaders(headers);
+        HashMap<String, String> headers = new HashMap<>();
+        request.setHeaders(buildHeaders(segmentedRequest, headers));
         return request;
     }
 
-    private HashMap<String, String> buildHeaders() {
-        String method = getMethod();
-        String path = getPath();
-        String version = getVersion();
-        headers.put("method", method);
-        headers.put("path", path);
-        headers.put("version", version);
+    private HashMap<String, String> buildHeaders(String[] segmentedRequest, HashMap<String, String> headers) {
+        headers.put("method", getMethod(segmentedRequest));
+        headers.put("path", getPath(segmentedRequest));
+        headers.put("version", getVersion(segmentedRequest));
         return headers;
     }
 
-    private String getMethod() { return segmentedRequest[0]; }
-
-    private String getPath() {
-        return segmentedRequest[1];
+    private String getMethod(String[] segmentedRequest) {
+        return segmentedRequest[REQUEST_METHOD_INDEX];
     }
 
-    private String getVersion() {
-        return segmentedRequest[2];
+    private String getPath(String[] segmentedRequest) {
+        return segmentedRequest[REQUEST_PATH_INDEX];
+    }
+
+    private String getVersion(String[] segmentedRequest) {
+        return segmentedRequest[REQUEST_VERSION_INDEX];
     }
 }

--- a/src/main/java/server/request/RequestParser.java
+++ b/src/main/java/server/request/RequestParser.java
@@ -1,6 +1,5 @@
 package main.java.server.request;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 public class RequestParser {

--- a/src/test/java/server/ClientTest.java
+++ b/src/test/java/server/ClientTest.java
@@ -28,14 +28,14 @@ public class ClientTest {
     }
 
     @Test
-    public void canWriteToSocket() throws IOException {
+    public void canWriteToSocket() {
         PrintWriter writer = client.getWriter();
         writer.println("message");
         assertEquals("message\n", socketStub.getOutputStream().toString());
     }
 
     @Test
-    public void canCloseSocketConnection() throws IOException {
+    public void canCloseSocketConnection() {
         client.close();
 
         assertTrue(socketStub.isClosed());

--- a/src/test/java/server/ClientTest.java
+++ b/src/test/java/server/ClientTest.java
@@ -1,0 +1,43 @@
+package test.java.server;
+
+import main.java.server.Client;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class ClientTest {
+    private Client client;
+    private SocketStub socketStub;
+
+    @Before
+    public void createClientWithSocketStub() throws IOException {
+        socketStub = new SocketStub("message");
+        client = new Client(socketStub);
+    }
+
+    @Test
+    public void canReadFromSocket() throws IOException {
+        BufferedReader reader = client.getReader();
+        assertEquals("message", reader.readLine());
+    }
+
+    @Test
+    public void canWriteToSocket() throws IOException {
+        PrintWriter writer = client.getWriter();
+        writer.println("message");
+        assertEquals("message\n", socketStub.getOutputStream().toString());
+    }
+
+    @Test
+    public void canCloseSocketConnection() throws IOException {
+        client.close();
+
+        assertTrue(socketStub.isClosed());
+    }
+}

--- a/src/test/java/server/RequestParserTest.java
+++ b/src/test/java/server/RequestParserTest.java
@@ -1,0 +1,33 @@
+package test.java.server;
+
+import main.java.server.request.Request;
+import main.java.server.request.RequestParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+
+public class RequestParserTest {
+
+    private RequestParser requestParser;
+
+    private static final String SIMPLE_GET = "GET /simple_get HTTP/1.1\r\n";
+
+    @Before
+    public void setUp() {
+        requestParser = new RequestParser();
+    }
+
+    @Test
+    public void generatesHeaderFields() throws IOException {
+        Request parsedRequest = requestParser.create(SIMPLE_GET);
+        HashMap<String, String> requestHeaders = parsedRequest.getHeaders();
+
+        assertEquals("GET", requestHeaders.get("method"));
+        assertEquals("/simple_get", requestHeaders.get("path"));
+        assertEquals("HTTP/1.1", requestHeaders.get("version"));
+    }
+}

--- a/src/test/java/server/RequestParserTest.java
+++ b/src/test/java/server/RequestParserTest.java
@@ -5,7 +5,6 @@ import main.java.server.request.RequestParser;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
 import java.util.HashMap;
 
 import static org.junit.Assert.assertEquals;
@@ -22,7 +21,7 @@ public class RequestParserTest {
     }
 
     @Test
-    public void generatesHeaderFields() throws IOException {
+    public void generatesHeaderFields() {
         Request parsedRequest = requestParser.create(SIMPLE_GET);
         HashMap<String, String> requestHeaders = parsedRequest.getHeaders();
 

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -6,8 +6,6 @@ import main.java.server.request.RequestParser;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.io.IOException;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -28,7 +26,7 @@ public class RouterTest {
     }
 
     @Test
-    public void returnsNotFoundIfPathIsUnknown() throws IOException {
+    public void returnsNotFoundIfPathIsUnknown() {
         Request request = requestParser.create(UNKNOWN_REQUEST);
         String response = router.route(request);
 
@@ -36,7 +34,7 @@ public class RouterTest {
     }
 
     @Test
-    public void returnsOKIfPathIsKnown() throws IOException {
+    public void returnsOKIfPathIsKnown() {
         Request request = requestParser.create(KNOWN_REQUEST);
         String response = router.route(request);
 
@@ -44,7 +42,7 @@ public class RouterTest {
     }
 
     @Test
-    public void doesNotReturnOkIfPathIsUnknown() throws IOException {
+    public void doesNotReturnOkIfPathIsUnknown() {
         Request request = requestParser.create(UNKNOWN_REQUEST);
         String response = router.route(request);
 

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -1,0 +1,54 @@
+package test.java.server;
+
+import main.java.server.Router;
+import main.java.server.request.Request;
+import main.java.server.request.RequestParser;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class RouterTest {
+
+    private Router router;
+    private RequestParser requestParser;
+
+    private static final String KNOWN_REQUEST = "GET /simple_get HTTP/1.1\r\n";
+    private static final String UNKNOWN_REQUEST = "GET /huh? HTTP/1.1\r\n";
+    private static final String OK = "HTTP/1.1 200 OK\r\n";
+    private static final String NOT_FOUND = "HTTP/1.1 404 Not Found\r\n";
+
+    @Before
+    public void setUp() {
+        router = new Router();
+        requestParser = new RequestParser();
+    }
+
+    @Test
+    public void returnsNotFoundIfPathIsUnknown() throws IOException {
+        Request request = requestParser.create(UNKNOWN_REQUEST);
+        String response = router.route(request);
+
+        assertEquals(NOT_FOUND, response);
+    }
+
+    @Test
+    public void returnsOKIfPathIsKnown() throws IOException {
+        Request request = requestParser.create(KNOWN_REQUEST);
+        String response = router.route(request);
+
+        assertEquals(OK, response);
+    }
+
+    @Test
+    public void doesNotReturnOkIfPathIsUnknown() throws IOException {
+        Request request = requestParser.create(UNKNOWN_REQUEST);
+        String response = router.route(request);
+
+        assertNotEquals(OK, response);
+    }
+}
+

--- a/src/test/java/server/SocketStub.java
+++ b/src/test/java/server/SocketStub.java
@@ -6,13 +6,11 @@ import java.io.OutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 
-public class SocketStub extends Socket {
-    private OutputStream outputStream;
-    private InputStream inputStream;
-    private String inputStub;
+class SocketStub extends Socket {
+    private final OutputStream outputStream;
+    private final InputStream inputStream;
 
-    public SocketStub(String inputStub) {
-        this.inputStub = inputStub;
+    SocketStub(String inputStub) {
         this.outputStream = new ByteArrayOutputStream();
         this.inputStream = new ByteArrayInputStream(inputStub.getBytes());
     }

--- a/src/test/java/server/SocketStub.java
+++ b/src/test/java/server/SocketStub.java
@@ -1,0 +1,29 @@
+package test.java.server;
+
+import java.net.Socket;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+public class SocketStub extends Socket {
+    private OutputStream outputStream;
+    private InputStream inputStream;
+    private String inputStub;
+
+    public SocketStub(String inputStub) {
+        this.inputStub = inputStub;
+        this.outputStream = new ByteArrayOutputStream();
+        this.inputStream = new ByteArrayInputStream(inputStub.getBytes());
+    }
+
+    @Override
+    public InputStream getInputStream() {
+        return inputStream;
+    }
+
+    @Override
+    public OutputStream getOutputStream() {
+        return outputStream;
+    }
+}


### PR DESCRIPTION
This feature implements the ability to access the server through localhost, and will respond with a 200 OK status when `/simple_get` path is requested. For all other paths 404 Not Found is returned. 

The `Route` class is eventually going to delegate requests to different handlers based on the type of request. Right now it's only setup to recognize the `/simple_get` path, otherwise the default response of 404 Not Found is returned as the response. 