### PR TITLE
Proxy

### DIFF
--- a/src/main/java/application/Handlers.java
+++ b/src/main/java/application/Handlers.java
@@ -10,4 +10,5 @@ class Handlers {
     static final Handler SimpleOptions = (Request request) -> ResponseTypes.assembleResponse(request, "");
     static final Handler EchoBody = (Request request) -> ResponseTypes.assembleResponse(request, request.getBody());
     static final Handler Redirect = (Request request) -> ResponseTypes.redirect(request, "/simple_get");
+    static final Handler Proxy = (Request request) -> ResponseTypes.proxy(request, request.getBody());
 }

--- a/src/main/java/application/Routes.java
+++ b/src/main/java/application/Routes.java
@@ -13,6 +13,7 @@ public class Routes {
     static {
         Router router = new Router();
         router.get("/simple_get", Handlers.SimpleGet);
+        router.get("/", Handlers.SimpleGet);
         router.head("/simple_get", Handlers.SimpleGet);
         router.options("/simple_get", Handlers.SimpleOptions);
 
@@ -33,7 +34,11 @@ public class Routes {
 
         router.get("/redirect", Handlers.Redirect);
 
-        router.get("/", Handlers.SimpleGet);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getroutes", Handlers.Proxy);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpredictions", Handlers.Proxy);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpatterns", Handlers.Proxy);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getstops", Handlers.Proxy);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getdirections", Handlers.Proxy);
 
         ROUTES = router.routes();
         ROUTER = router;

--- a/src/main/java/application/Routes.java
+++ b/src/main/java/application/Routes.java
@@ -34,11 +34,11 @@ public class Routes {
 
         router.get("/redirect", Handlers.Redirect);
 
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getroutes", Handlers.Proxy);
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpredictions", Handlers.Proxy);
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpatterns", Handlers.Proxy);
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getstops", Handlers.Proxy);
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getdirections", Handlers.Proxy);
+        router.get("/getroutes", Handlers.Proxy);
+        router.get("/getpredictions", Handlers.Proxy);
+        router.get("/getpatterns", Handlers.Proxy);
+        router.get("/getstops", Handlers.Proxy);
+        router.get("/getdirections", Handlers.Proxy);
 
         ROUTES = router.routes();
         ROUTER = router;

--- a/src/main/java/server/ProxyHandler.java
+++ b/src/main/java/server/ProxyHandler.java
@@ -1,0 +1,30 @@
+package main.java.server;
+
+import main.java.server.request.Request;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+public class ProxyHandler {
+
+    public static String sendRequest(Request request) throws IOException {
+        String path = request.getRequestPath().substring(1);
+
+        URL url = new URL(path);
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+
+        BufferedReader in = new BufferedReader(
+                new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuffer content = new StringBuffer();
+        while ((inputLine = in.readLine()) != null) {
+            content.append(inputLine);
+        }
+
+        in.close();
+        return content.toString();
+    }
+}

--- a/src/main/java/server/ProxyHandler.java
+++ b/src/main/java/server/ProxyHandler.java
@@ -19,12 +19,14 @@ public class ProxyHandler {
         BufferedReader in = new BufferedReader(
                 new InputStreamReader(con.getInputStream()));
         String inputLine;
-        StringBuffer content = new StringBuffer();
+        StringBuilder content = new StringBuilder();
         while ((inputLine = in.readLine()) != null) {
             content.append(inputLine);
         }
 
         in.close();
+        con.disconnect();
+
         return content.toString();
     }
 }

--- a/src/main/java/server/Router.java
+++ b/src/main/java/server/Router.java
@@ -7,6 +7,7 @@ import main.java.server.response.Response;
 import main.java.server.response.ResponseTypes;
 
 import java.util.HashMap;
+import java.util.Set;
 import java.util.TreeMap;
 
 import static main.java.server.HTTPMessageComponents.HTTPMethods.*;
@@ -40,30 +41,33 @@ public class Router implements Handler {
     }
 
     public Response generateResponse(Request request) {
+        String path = request.getRequestPath();
+        if(path.contains("?")){
+            path = path.split("\\?")[0];
+        }
 
-        if (!pathExists(request)) {
-
+        if (!pathExists(path)) {
             return ResponseTypes.notFound(request);
         }
 
-        if (!methodAllowed(request)) {
+        if (!methodAllowed(request, path)) {
             HashMap<String, Handler> pathMethods = routes.get(request.getRequestPath());
 
             return ResponseTypes.notAllowed(request, pathMethods);
         }
 
-        return routes.get(request.getRequestPath()).get(request.getRequestMethod().name()).generateResponse(request);
+        return routes.get(path).get(request.getRequestMethod().name()).generateResponse(request);
     }
 
-    private boolean pathExists(Request request) {
+    private boolean pathExists(String path) {
         return routes()
                 .keySet()
-                .contains(request.getRequestPath());
+                .contains(path);
     }
 
-    private boolean methodAllowed(Request request) {
+    private boolean methodAllowed(Request request, String path) {
         return routes()
-                .get(request.getRequestPath())
+                .get(path)
                 .containsKey(request.getRequestMethod().name());
     }
 }

--- a/src/main/java/server/ServerRunner.java
+++ b/src/main/java/server/ServerRunner.java
@@ -10,10 +10,6 @@ import main.java.server.response.Response;
 import main.java.server.response.ResponseFormatter;
 import main.java.server.response.ResponseTypes;
 
-import static main.java.server.HTTPMessageComponents.HTTPSyntax.*;
-import static main.java.server.HTTPMessageComponents.StatusCodes.INTERNAL_ERROR;
-
-
 public class ServerRunner implements Runnable {
     private final RequestParser requestParser = new RequestParser();
     private final Client client;

--- a/src/main/java/server/response/ResponseTypes.java
+++ b/src/main/java/server/response/ResponseTypes.java
@@ -63,6 +63,7 @@ public class ResponseTypes {
         }
         return new Response.Builder()
                 .withStatus(VERSION + SP + OK+ CRLF)
+                .withHeader(ALLOW, "GET")
                 .withBody(proxyPayload)
                 .build();
     }

--- a/src/main/java/server/response/ResponseTypes.java
+++ b/src/main/java/server/response/ResponseTypes.java
@@ -1,10 +1,12 @@
 package main.java.server.response;
 
 import main.java.application.Routes;
+import main.java.server.ProxyHandler;
 import main.java.server.request.Request;
 import static main.java.server.HTTPMessageComponents.HTTPSyntax.*;
 import static main.java.server.HTTPMessageComponents.StatusCodes.*;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.Set;
 
@@ -48,6 +50,20 @@ public class ResponseTypes {
     public static Response internalError() {
         return new Response.Builder()
                 .withStatus(VERSION + SP + INTERNAL_ERROR + CRLF)
+                .build();
+    }
+
+    public static Response proxy(Request request, String s) {
+        String proxyPayload;
+        try {
+            proxyPayload = ProxyHandler.sendRequest(request);
+        } catch (IOException e) {
+            e.printStackTrace();
+            return ResponseTypes.internalError();
+        }
+        return new Response.Builder()
+                .withStatus(VERSION + SP + OK+ CRLF)
+                .withBody(proxyPayload)
                 .build();
     }
 }

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -23,6 +23,7 @@ public class RouterTest {
     public void setUp() {
         router = new Router();
         router.get("/simple_get", HandlersStub.SimpleGet);
+        router.get("/", HandlersStub.SimpleGet);
         router.head("/simple_get", HandlersStub.SimpleGet);
         router.get("/redirect", HandlersStub.Redirect);
         router.head("/get_with_body", HandlersStub.GetWithBody);
@@ -32,12 +33,29 @@ public class RouterTest {
         router.options("/method_options", HandlersStub.SimpleOptions);
         router.put("/method_options_2", HandlersStub.EchoBody);
         router.post("/echo_body", HandlersStub.EchoBody);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpredictions", HandlersStub.EchoBody);
     }
 
     @Test
     public void canProcessGETRequestIfRouteHasBeenAdded()  {
         Request simpleGetRequest = new Request(new StatusLine(GET, "/simple_get", VERSION));
         Response getResponse = router.generateResponse(simpleGetRequest);
+
+        assertEquals("HTTP/1.1 200 OK\r\n", getResponse.getStatusLine());
+    }
+
+    @Test
+    public void returns404IfRouteHasNotBeenAdded()  {
+        Request notFoundRequest = new Request(new StatusLine(GET, "/not_found", VERSION));
+        Response getResponse = router.generateResponse(notFoundRequest);
+
+        assertEquals("HTTP/1.1 404 Not Found\r\n", getResponse.getStatusLine());
+    }
+
+    @Test
+    public void canProcessProxyRequestIfRouteHasBeenAdded()  {
+        Request proxyRequest = new Request(new StatusLine(GET, "/http://www.ctabustracker.com/bustime/api/v2/getpredictions", VERSION));
+        Response getResponse = router.generateResponse(proxyRequest);
 
         assertEquals("HTTP/1.1 200 OK\r\n", getResponse.getStatusLine());
     }

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -15,6 +15,7 @@ import static junit.framework.TestCase.assertTrue;
 import static junit.framework.TestCase.assertEquals;
 import static main.java.server.HTTPMessageComponents.HTTPMethods.*;
 import static main.java.server.HTTPMessageComponents.HTTPSyntax.*;
+import static main.java.server.HTTPMessageComponents.StatusCodes.OK;
 
 public class RouterTest {
     private Router router;
@@ -33,7 +34,7 @@ public class RouterTest {
         router.options("/method_options", HandlersStub.SimpleOptions);
         router.put("/method_options_2", HandlersStub.EchoBody);
         router.post("/echo_body", HandlersStub.EchoBody);
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpredictions", HandlersStub.EchoBody);
+        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpredictions", HandlersStub.Proxy);
     }
 
     @Test
@@ -54,7 +55,7 @@ public class RouterTest {
 
     @Test
     public void canProcessProxyRequestIfRouteHasBeenAdded()  {
-        Request proxyRequest = new Request(new StatusLine(GET, "/http://www.ctabustracker.com/bustime/api/v2/getpredictions", VERSION));
+        Request proxyRequest = new Request(new StatusLine(GET, "/http://www.ctabustracker.com/bustime/api/v2/getpredictions?key=key&rt=20&stpid=456&format=json", VERSION));
         Response getResponse = router.generateResponse(proxyRequest);
 
         assertEquals("HTTP/1.1 200 OK\r\n", getResponse.getStatusLine());
@@ -120,6 +121,7 @@ public class RouterTest {
         static final Handler SimpleOptions = (Request request) -> ResponseTypes.assembleResponse(request, "");
         static final Handler EchoBody = (Request request) -> ResponseTypes.assembleResponse(request, request.getBody());
         static final Handler Redirect = (Request request) -> ResponseTypes.redirect(request, "/redirected_uri");
+        static final Handler Proxy = (Request request) ->  new Response.Builder().withStatus(VERSION + SP + OK + CRLF).build();
     }
 
 }

--- a/src/test/java/server/RouterTest.java
+++ b/src/test/java/server/RouterTest.java
@@ -34,7 +34,7 @@ public class RouterTest {
         router.options("/method_options", HandlersStub.SimpleOptions);
         router.put("/method_options_2", HandlersStub.EchoBody);
         router.post("/echo_body", HandlersStub.EchoBody);
-        router.get("/http://www.ctabustracker.com/bustime/api/v2/getpredictions", HandlersStub.Proxy);
+        router.get("/getroutes", HandlersStub.Proxy);
     }
 
     @Test
@@ -55,7 +55,7 @@ public class RouterTest {
 
     @Test
     public void canProcessProxyRequestIfRouteHasBeenAdded()  {
-        Request proxyRequest = new Request(new StatusLine(GET, "/http://www.ctabustracker.com/bustime/api/v2/getpredictions?key=key&rt=20&stpid=456&format=json", VERSION));
+        Request proxyRequest = new Request(new StatusLine(GET, "/http://www.ctabustracker.com/bustime/api/v2/getroutes?key=key&rt=20&stpid=456&format=json", VERSION));
         Response getResponse = router.generateResponse(proxyRequest);
 
         assertEquals("HTTP/1.1 200 OK\r\n", getResponse.getStatusLine());
@@ -113,6 +113,22 @@ public class RouterTest {
         assertEquals("HTTP/1.1 405 Method Not Allowed\r\n", notAllowedResponse.getStatusLine());
         assertEquals("HEAD,OPTIONS", notAllowedResponse.getHeaders().get("Allow"));
         assertTrue(notAllowedResponse.getBody().isEmpty());
+    }
+
+    @Test
+    public void canCleanAProxyPathWithParams()  {
+        Request proxyPathRequest = new Request(new StatusLine(GET, "http://www.ctabustracker.com/bustime/api/v2/getroutes?key=g86g7g6g6g&rt=70@format=json", VERSION));
+        Response proxyPathResponse = router.generateResponse(proxyPathRequest);
+
+        assertEquals("HTTP/1.1 200 OK\r\n", proxyPathResponse.getStatusLine());
+    }
+
+    @Test
+    public void correctlyRoutesRoutePath()  {
+        Request routeRequest = new Request(new StatusLine(GET, "/", VERSION));
+        Response routeResponse = router.generateResponse(routeRequest);
+
+        assertEquals("HTTP/1.1 200 OK\r\n", routeResponse.getStatusLine());
     }
 
     static class HandlersStub {


### PR DESCRIPTION
This adds the ability to use the server as a proxy server in order to fetch json data from an external api. 

This is done by adding new `routes` with the path defined as the api url minus any parameters, and then pointing those endpoints to a `proxyHandler` that makes the request to the api and returns the body of the response. Then that data is added to the body of the response that the server sends back to the client. 